### PR TITLE
Added Filter Component

### DIFF
--- a/src/Client/Client.fsproj
+++ b/src/Client/Client.fsproj
@@ -41,6 +41,7 @@
         <Compile Include="./Components/Menu.fs"/>
         <Compile Include="./Components/NavBar.fs"/>
         <Compile Include="./Views/Patient.fs"/>
+        <Compile Include="./Views/Filter.fs"/>
         <Compile Include="./Views/EmergencyList.fs"/>
         <Compile Include="./Pages/LifeSupport.fs"/>
         <Compile Include="./Pages/ContinuousMeds.fs"/>

--- a/src/Client/Components/Select.fs
+++ b/src/Client/Components/Select.fs
@@ -79,12 +79,7 @@ module Select =
                             prop.key i
                             prop.value s
                             prop.onClick (fun _ -> item |> Select |> dispatch)
-                            menuItem.children [
-                                Mui.typography [
-                                    typography.variant.h6
-                                    prop.text s
-                                ]
-                            ]
+                            prop.text s
                         ]
                     )
                     |> select.children

--- a/src/Client/Utils.fs
+++ b/src/Client/Utils.fs
@@ -1,6 +1,5 @@
 namespace Utils
 
-
 module Typography =
 
     open Feliz
@@ -115,12 +114,18 @@ module GoogleDocs =
 
 module Sort =
 
+    open Shared.Localization
+
         type Sort =
         | IndicationAsc
         | IndicationDesc
         | InterventionAsc
         | InterventionDesc
 
-        let sortableItems = ["Indication ASC", IndicationAsc; "Indication DESC", IndicationDesc; "Intervention ASC", InterventionAsc; "Intervention DESC", InterventionDesc]
 
-        let sortItems = (sortableItems |> List.map (fun (label, _) -> label))
+        let indication(lang) = Terms.``Emergency List Indication`` |> getTerm lang
+        let intervention(lang) = Terms.``Emergency List Intervention`` |> getTerm lang
+
+        let sortableItems(lang) = [$"{indication lang} ASC", IndicationAsc; $"{indication lang} DESC", IndicationDesc; $"{intervention lang} ASC", InterventionAsc; $"{intervention lang} DESC", InterventionDesc]
+
+        let sortItems(lang) = (sortableItems lang |> List.map (fun (label, _) -> label))

--- a/src/Client/Views/Filter.fs
+++ b/src/Client/Views/Filter.fs
@@ -1,0 +1,146 @@
+namespace Components
+
+module Filter =
+
+    open Elmish
+    open Feliz
+    open MaterialUI5
+    open FSharp.Core
+    open Feliz.UseElmish
+    open Components
+    open Shared
+    open Localization
+    open Utils.Sort
+
+    type Msg =
+        | SetSort of Sort
+        | SetIntervention of string
+        | SetIndication of string
+        | Filter
+        | ResetFilter
+
+    type Model = {
+        InterventionList : Intervention list
+        FilteredList : Intervention list
+        Sort: Sort
+        Indications: string list
+        SelectedIndication : Option<string>
+        Interventions: string list
+        SelectedIntervention: Option<string>
+    }
+
+    let init(interventionList : Intervention list) =
+        {
+            InterventionList = interventionList
+            FilteredList = interventionList
+            Sort = Sort.IndicationAsc
+            Interventions = interventionList |> List.map (fun x -> x.Name) |> List.distinct |> List.sort;
+            Indications = interventionList |> List.map (fun x -> x.Indication) |> List.distinct |> List.sort;
+            SelectedIndication = Option.None;
+            SelectedIntervention = Option.None}, Cmd.ofMsg(SetSort IndicationAsc;)
+
+
+    let doSortAndFilter(state : Model): Intervention list =
+
+        Browser.Dom.console.table state
+        let indicationList = match state.SelectedIndication with
+                                | Some s -> state.FilteredList |> List.filter (fun bolus -> bolus.Indication = s)
+                                | None -> state.FilteredList
+
+        let interventionList = match state.SelectedIntervention with
+                                | Some s -> indicationList |> List.filter (fun bolus -> bolus.Name = s)
+                                | None -> indicationList
+
+        let sortedList = match state.Sort with
+                            | IndicationAsc -> interventionList |> List.sortBy (fun item -> item.Indication )
+                            | IndicationDesc -> interventionList |> List.sortByDescending (fun item -> item.Indication )
+                            | InterventionAsc -> interventionList |> List.sortBy (fun item -> item.Name )
+                            | InterventionDesc -> interventionList |> List.sortByDescending (fun item -> item.Name )
+
+        sortedList
+
+    let indications indications =
+        indications |> List.distinct |> List.sort
+
+    let interventions (state: Model) =
+        match state.SelectedIndication with
+        | Some  s -> state.InterventionList
+                    |> List.filter(fun bolus -> bolus.Indication = s)
+                    |> List.map(fun item -> item.Name)
+                    |> List.distinct
+        | None -> state.InterventionList
+                    |> List.map(fun item -> item.Name)
+                    |> List.distinct
+
+    let update publish msg state =
+
+        match msg with
+        | SetSort s -> { state with Sort = s}, Cmd.ofMsg Filter
+        | SetIndication s -> { state with SelectedIndication = Some(s); Interventions = (interventions state)}, Cmd.ofMsg Filter
+        | SetIntervention s -> {state with SelectedIntervention = Some(s);}, Cmd.ofMsg Filter
+        | Filter ->
+            let data = doSortAndFilter(state)
+            publish data
+            {state with FilteredList = data}, Cmd.none
+        | ResetFilter ->
+            publish (state.InterventionList |> List.sortBy( fun x-> x.Indication))
+            {
+                state with FilteredList = state.InterventionList |> List.sortBy( fun x-> x.Indication);
+                            SelectedIndication = Option.None;
+                            SelectedIntervention = Option.None;
+                            Sort = Sort.IndicationAsc}, Cmd.none
+
+    [<ReactComponent>]
+    let View
+        publish
+        (props : {|
+                    indicationLabel : ReactElement
+                    interventionLabel : ReactElement
+                    interventionList: Intervention list
+                    lang : Locales
+
+        |}) =
+
+            let state, dispatch =
+                    React.useElmish (init props.interventionList, update publish,[||])
+
+            let sortValue = (Some(sortableItems props.lang |> List.find (fun (_, sort) -> sort = state.Sort) |> fst))
+            let handleSortSelect = (fun item -> sortableItems props.lang |> List.find (fun (key, value) ->  key = item ) |> snd |> SetSort |> dispatch)
+            let handleIndicationSelect =  (fun item -> indications state.Indications |> List.find ( fun key -> key = item) |> SetIndication |> dispatch )
+            let handleInterventionSelect = (fun item -> interventions(state) |> List.find ( fun key -> key = item) |> SetIntervention |> dispatch )
+
+            Mui.box[
+                prop.style [style.display.flex; style.alignItems.center]
+                prop.children[
+                    Mui.formGroup[
+                        formGroup.row true
+                        prop.style[style.display.flex]
+                        formGroup.children[
+                            Select.render props.indicationLabel (indications state.Indications) state.SelectedIndication handleIndicationSelect
+                            Select.render props.interventionLabel (interventions state) state.SelectedIntervention handleInterventionSelect
+                            Select.render (Utils.Typography.body1 (Localization.Terms.``Sort By`` |> getTerm props.lang)) (sortItems props.lang) sortValue handleSortSelect
+                            Mui.formControl[
+                                formControl.margin.dense
+                                formControl.children[
+                                    Mui.button[
+                                        prop.style [style.height 65]
+                                        prop.text (Localization.Terms.``Reset Filter`` |> getTerm props.lang)
+                                        button.variant.contained
+                                        prop.onClick (fun _ -> ResetFilter |> dispatch)
+                                    ]
+                                ]
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+
+
+    let render publish
+            (props : {|
+                    indicationLabel : ReactElement
+                    interventionLabel : ReactElement
+                    interventionList: Intervention list
+                    lang : Locales
+        |}) =
+            View publish props

--- a/src/Shared/Localization.fs
+++ b/src/Shared/Localization.fs
@@ -68,6 +68,7 @@ module Localization =
             | ``Continuous Medication Dose``
             | ``Continuous Medication Advice``
             | ``Sort By``
+            | ``Reset Filter``
 
     open Terms
 
@@ -112,6 +113,7 @@ module Localization =
             | ``Continuous Medication Dose`` -> "Dose"
             | ``Continuous Medication Advice`` -> "Advice"
             | ``Sort By`` -> "Sort By"
+            | ``Reset Filter`` -> "Reset Filter"
 
         | Dutch ->
             match term with
@@ -152,3 +154,4 @@ module Localization =
             | ``Continuous Medication Dose`` -> "Dosering"
             | ``Continuous Medication Advice`` -> "Advies"
             | ``Sort By`` -> "Sorteren op"
+            | ``Reset Filter`` -> "filter resetten"


### PR DESCRIPTION
This PR creates a filter component for the emergency and continuous medication pages.

This Filters accepts as an input a list of Interventions, performs sort and filter operations on that list and publishes a list of interventions for the calling. page to render.

There's some CSS issues outstanding like aligning buttons with select boxes correctly, but the functionality is all there.