### PR TITLE
chore: fix typo in test

### DIFF
--- a/tests/Informedica.GenUnits.Tests/Tests.fs
+++ b/tests/Informedica.GenUnits.Tests/Tests.fs
@@ -400,7 +400,7 @@ module Tests =
              |> Expect.isTrue ""
             }
 
-            test "can add or subrract within the same unit group" {
+            test "can add or subtract within the same unit group" {
              (l5 + ml50) >? l5
              |> Expect.isTrue  ""
 
@@ -408,7 +408,7 @@ module Tests =
              |> Expect.isTrue ""
             }
 
-            test "cannot add or subrract with different unit groups" {
+            test "cannot add or subtract with different unit groups" {
              (fun _ -> (l5 + mg400) >? l5 |> ignore)
              |> Expect.throws ""
 


### PR DESCRIPTION
just a typo in a test name